### PR TITLE
Removed the bcrypt dependency #9

### DIFF
--- a/academic-hub-backend/package.json
+++ b/academic-hub-backend/package.json
@@ -19,7 +19,6 @@
   "type": "commonjs",
   "dependencies": {
     "axios": "^1.7.2",
-    "bcrypt": "^6.0.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
Removed bcrypt dependency from package.json and it lead to the reduction in bundle size and removed all the confusion.