### PR TITLE
fix: removes unnecessary fields from Ideas Page

### DIFF
--- a/academic-hub-frontend/src/pages/IdeasPage.js
+++ b/academic-hub-frontend/src/pages/IdeasPage.js
@@ -15,10 +15,8 @@ const IdeasPage = () => {
 
   const categories = [
     { value: 'all', label: 'All Ideas' },
-    { value: 'study', label: 'Study' },
     { value: 'project', label: 'Project' },
-    { value: 'research', label: 'Research' },
-    { value: 'general', label: 'General' }
+    { value: 'research', label: 'Research' }
   ];
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR Removes Unnecessary Fields from Ideas Page

Closes #39

## Screnshots:

<img width="1920" height="910" alt="Screenshot (2862)" src="https://github.com/user-attachments/assets/252be109-285e-4f15-83e7-43d7c8b1cbfd" />

