### PR TITLE
Add frontend pagination to Subjects page

### DIFF
--- a/academic-hub-frontend/src/pages/SubjectsPage.css
+++ b/academic-hub-frontend/src/pages/SubjectsPage.css
@@ -21,3 +21,27 @@
     gap: 1.25rem;
   }
 }
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.page-info {
+  font-weight: 500;
+}
+/* Floating Add Subject Button */
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000; /* ensures button stays above pagination */
+}
+
+/* Ensure pagination does not block floating elements */
+.pagination {
+  position: relative;
+  z-index: 1;
+}

--- a/academic-hub-frontend/src/pages/SubjectsPage.js
+++ b/academic-hub-frontend/src/pages/SubjectsPage.js
@@ -14,13 +14,12 @@ const SubjectsPage = () => {
   const [showForm, setShowForm] = useState(false);
   const [editingSubject, setEditingSubject] = useState(null);
 
-  useEffect(() => {
-    fetchSubjects();
-  }, [token]);
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const subjectsPerPage = 5;
 
+  useEffect(() => {
   const fetchSubjects = async () => {
-    // Check if user is authenticated before making API call
-    // Use token from context which is reactive
     if (!token) {
       setLoading(false);
       return;
@@ -36,6 +35,13 @@ const SubjectsPage = () => {
       setLoading(false);
     }
   };
+
+  fetchSubjects();
+}, [token]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [subjects.length]);
 
   const handleCreateSubject = async (subjectData) => {
     try {
@@ -106,6 +112,16 @@ const SubjectsPage = () => {
       alert(error.response?.data?.message || 'Failed to update progress');
     }
   };
+  // Pagination calculations
+  const indexOfLastSubject = currentPage * subjectsPerPage;
+  const indexOfFirstSubject = indexOfLastSubject - subjectsPerPage;
+  const currentSubjects = subjects.slice(
+    indexOfFirstSubject,
+    indexOfLastSubject
+  );
+
+  const totalPages = Math.ceil(subjects.length / subjectsPerPage);
+
 
 
   if (loading) {
@@ -142,7 +158,7 @@ const SubjectsPage = () => {
 
       <div className="subjects-grid">
         {subjects.length > 0 ? (
-          subjects.map(subject => (
+          currentSubjects.map(subject => (
             <SubjectCard
               key={subject._id}
               subject={subject}
@@ -164,7 +180,30 @@ const SubjectsPage = () => {
           </div>
         )}
       </div>
+      {subjects.length > subjectsPerPage && (
+      <div className="pagination">
+        <button
+          className="btn"
+          disabled={currentPage === 1}
+          onClick={() => setCurrentPage(prev => prev - 1)}
+        >
+          Previous
+        </button>
 
+        <span className="page-info">
+          Page {currentPage} of {totalPages}
+        </span>
+
+        <button
+          className="btn"
+          disabled={currentPage === totalPages}
+          onClick={() => setCurrentPage(prev => prev + 1)}
+        >
+          Next
+        </button>
+      </div>
+    )}
+  
       <button
         className="fab"
         onClick={() => setShowForm(true)}


### PR DESCRIPTION
### ✅ Summary
This PR adds frontend-only pagination to the Subjects page to improve performance and usability when handling a large number of subjects.

### 🛠️ Changes Made
- Implemented frontend pagination (5 items per page)
- Added Previous / Next navigation controls
- Ensured pagination resets correctly on add/delete
- Fixed a minor UI overlap introduced by pagination that prevented the “Add Subject” button from being clickable

### 🧪 Testing
- Pagination logic and UI behavior were tested at the frontend level
- Verified page navigation, edge cases (≤5 items), and layout stability
- Backend testing depends on MongoDB configuration (MongoDB Memory Server or `MONGO_URI`) and could not be completed due to local environment limitations

### 🏷️ Program
ECWoC'2026

### 📌 Issue Reference
Closes #80